### PR TITLE
結果画面の説明の追加 #49

### DIFF
--- a/Shared/ResultView.swift
+++ b/Shared/ResultView.swift
@@ -44,6 +44,12 @@ struct ResultView: View {
                 }
             }
             if(self.isCountDown){
+                Text("👆気になる研究室の写真を押してみてね👆")
+                    .font(.system(size:30))
+                    .fontWeight(.thin)
+                    .foregroundColor(Color.orange)
+                    .padding()
+                
                 Button(action:{
                     dismiss()
                     envData.isNavigationActive.wrappedValue=false


### PR DESCRIPTION
### 機能
結果ページの画像クリックを促すテキストを追加

### 概要
![スクリーンショット 2022-07-11 18 36 44](https://user-images.githubusercontent.com/94606424/178235382-41793ecb-5b9f-4d7c-b190-34d8d2b84688.png)

